### PR TITLE
#6 - 리팩토링: session의 member 도메인 리팩토링

### DIFF
--- a/src/main/java/com/example/login/global/member/domain/Member.java
+++ b/src/main/java/com/example/login/global/member/domain/Member.java
@@ -1,4 +1,4 @@
-package com.example.login.session.member.domain;
+package com.example.login.global.member.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/example/login/global/member/domain/MemberSession.java
+++ b/src/main/java/com/example/login/global/member/domain/MemberSession.java
@@ -1,4 +1,4 @@
-package com.example.login.session.member.domain;
+package com.example.login.global.member.domain;
 
 import lombok.Builder;
 
@@ -8,6 +8,8 @@ public record MemberSession(
         String userId,
         String password
         ){
+
+    public static final String MEMBER_SESSION = "MemberSession";
 
     @Builder
     public static MemberSession of(Long id, String username, String userId, String password) {

--- a/src/main/java/com/example/login/global/member/dto/LoginForm.java
+++ b/src/main/java/com/example/login/global/member/dto/LoginForm.java
@@ -1,4 +1,4 @@
-package com.example.login.session.member.dto;
+package com.example.login.global.member.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/example/login/global/member/dto/SignUpForm.java
+++ b/src/main/java/com/example/login/global/member/dto/SignUpForm.java
@@ -1,6 +1,6 @@
-package com.example.login.session.member.dto;
+package com.example.login.global.member.dto;
 
-import com.example.login.session.member.domain.Member;
+import com.example.login.global.member.domain.Member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/java/com/example/login/global/member/exception/MemberDuplicationException.java
+++ b/src/main/java/com/example/login/global/member/exception/MemberDuplicationException.java
@@ -1,4 +1,4 @@
-package com.example.login.session.member.exception;
+package com.example.login.global.member.exception;
 
 import com.example.login.global.exception.DuplicationException;
 

--- a/src/main/java/com/example/login/global/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/example/login/global/member/exception/MemberNotFoundException.java
@@ -1,4 +1,4 @@
-package com.example.login.session.member.exception;
+package com.example.login.global.member.exception;
 
 import com.example.login.global.exception.NotFoundException;
 

--- a/src/main/java/com/example/login/global/member/exception/MemberPasswordNotMatchException.java
+++ b/src/main/java/com/example/login/global/member/exception/MemberPasswordNotMatchException.java
@@ -1,4 +1,4 @@
-package com.example.login.session.member.exception;
+package com.example.login.global.member.exception;
 
 import com.example.login.global.exception.NotMatchException;
 

--- a/src/main/java/com/example/login/global/member/exception/MemberUnauthorizedException.java
+++ b/src/main/java/com/example/login/global/member/exception/MemberUnauthorizedException.java
@@ -1,4 +1,4 @@
-package com.example.login.session.member.exception;
+package com.example.login.global.member.exception;
 
 import com.example.login.global.exception.UnauthorizedException;
 

--- a/src/main/java/com/example/login/global/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/login/global/member/repository/MemberRepository.java
@@ -1,6 +1,6 @@
-package com.example.login.session.member.repository;
+package com.example.login.global.member.repository;
 
-import com.example.login.session.member.domain.Member;
+import com.example.login.global.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/example/login/session/argumentresolver/LoginArgumentResolver.java
+++ b/src/main/java/com/example/login/session/argumentresolver/LoginArgumentResolver.java
@@ -1,7 +1,7 @@
 package com.example.login.session.argumentresolver;
 
-import com.example.login.session.member.domain.MemberSession;
-import com.example.login.session.member.exception.MemberUnauthorizedException;
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.exception.MemberUnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +11,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import static com.example.login.session.member.domain.constant.LoginStaticField.MEMBER_SESSION;
+import static com.example.login.global.member.domain.MemberSession.MEMBER_SESSION;
 
 @Slf4j
 public class LoginArgumentResolver implements HandlerMethodArgumentResolver {

--- a/src/main/java/com/example/login/session/argumentresolver/controller/ArgumentResolverLoginController.java
+++ b/src/main/java/com/example/login/session/argumentresolver/controller/ArgumentResolverLoginController.java
@@ -1,9 +1,9 @@
 package com.example.login.session.argumentresolver.controller;
 
 import com.example.login.session.argumentresolver.Login;
-import com.example.login.session.member.domain.MemberSession;
-import com.example.login.session.member.dto.LoginForm;
-import com.example.login.session.member.dto.SignUpForm;
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.dto.LoginForm;
+import com.example.login.global.member.dto.SignUpForm;
 import com.example.login.session.member.dto.MemberResponse;
 import com.example.login.session.member.service.LoginService;
 import com.example.login.session.member.service.MemberService;

--- a/src/main/java/com/example/login/session/filter/LoginCheckFilter.java
+++ b/src/main/java/com/example/login/session/filter/LoginCheckFilter.java
@@ -9,7 +9,7 @@ import org.springframework.util.PatternMatchUtils;
 
 import java.io.IOException;
 
-import static com.example.login.session.member.domain.constant.LoginStaticField.MEMBER_SESSION;
+import static com.example.login.global.member.domain.MemberSession.MEMBER_SESSION;
 
 @Slf4j
 public class LoginCheckFilter implements Filter {

--- a/src/main/java/com/example/login/session/filter/controller/FilterLoginController.java
+++ b/src/main/java/com/example/login/session/filter/controller/FilterLoginController.java
@@ -1,7 +1,7 @@
 package com.example.login.session.filter.controller;
 
-import com.example.login.session.member.dto.LoginForm;
-import com.example.login.session.member.dto.SignUpForm;
+import com.example.login.global.member.dto.LoginForm;
+import com.example.login.global.member.dto.SignUpForm;
 import com.example.login.session.member.dto.MemberResponse;
 import com.example.login.session.member.service.LoginService;
 import com.example.login.session.member.service.MemberService;

--- a/src/main/java/com/example/login/session/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/example/login/session/interceptor/LoginCheckInterceptor.java
@@ -6,7 +6,7 @@ import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import static com.example.login.session.member.domain.constant.LoginStaticField.MEMBER_SESSION;
+import static com.example.login.global.member.domain.MemberSession.MEMBER_SESSION;
 
 
 @Slf4j

--- a/src/main/java/com/example/login/session/interceptor/controller/InterceptorLoginController.java
+++ b/src/main/java/com/example/login/session/interceptor/controller/InterceptorLoginController.java
@@ -1,7 +1,7 @@
 package com.example.login.session.interceptor.controller;
 
-import com.example.login.session.member.dto.LoginForm;
-import com.example.login.session.member.dto.SignUpForm;
+import com.example.login.global.member.dto.LoginForm;
+import com.example.login.global.member.dto.SignUpForm;
 import com.example.login.session.member.dto.MemberResponse;
 import com.example.login.session.member.service.LoginService;
 import com.example.login.session.member.service.MemberService;

--- a/src/main/java/com/example/login/session/member/domain/constant/LoginStaticField.java
+++ b/src/main/java/com/example/login/session/member/domain/constant/LoginStaticField.java
@@ -1,6 +1,0 @@
-package com.example.login.session.member.domain.constant;
-
-public class LoginStaticField {
-
-    public static final String MEMBER_SESSION = "MemberSession";
-}

--- a/src/main/java/com/example/login/session/member/dto/MemberDto.java
+++ b/src/main/java/com/example/login/session/member/dto/MemberDto.java
@@ -1,6 +1,6 @@
 package com.example.login.session.member.dto;
 
-import com.example.login.session.member.domain.Member;
+import com.example.login.global.member.domain.Member;
 
 public record MemberDto(
         Long id,

--- a/src/main/java/com/example/login/session/member/service/LoginService.java
+++ b/src/main/java/com/example/login/session/member/service/LoginService.java
@@ -1,14 +1,14 @@
 package com.example.login.session.member.service;
 
 
-import com.example.login.session.member.domain.Member;
-import com.example.login.session.member.domain.MemberSession;
-import com.example.login.session.member.dto.LoginForm;
-import com.example.login.session.member.dto.SignUpForm;
+import com.example.login.global.member.domain.Member;
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.dto.LoginForm;
+import com.example.login.global.member.dto.SignUpForm;
+import com.example.login.global.member.exception.MemberNotFoundException;
+import com.example.login.global.member.exception.MemberPasswordNotMatchException;
+import com.example.login.global.member.repository.MemberRepository;
 import com.example.login.session.member.dto.MemberDto;
-import com.example.login.session.member.exception.MemberNotFoundException;
-import com.example.login.session.member.exception.MemberPasswordNotMatchException;
-import com.example.login.session.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.example.login.session.member.domain.constant.LoginStaticField.MEMBER_SESSION;
+import static com.example.login.global.member.domain.MemberSession.MEMBER_SESSION;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/com/example/login/session/member/service/MemberService.java
+++ b/src/main/java/com/example/login/session/member/service/MemberService.java
@@ -1,12 +1,12 @@
 package com.example.login.session.member.service;
 
-import com.example.login.session.member.domain.Member;
-import com.example.login.session.member.domain.MemberSession;
-import com.example.login.session.member.dto.SignUpForm;
+import com.example.login.global.member.domain.Member;
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.dto.SignUpForm;
+import com.example.login.global.member.exception.MemberDuplicationException;
+import com.example.login.global.member.exception.MemberNotFoundException;
+import com.example.login.global.member.repository.MemberRepository;
 import com.example.login.session.member.dto.MemberDto;
-import com.example.login.session.member.exception.MemberDuplicationException;
-import com.example.login.session.member.exception.MemberNotFoundException;
-import com.example.login.session.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import static com.example.login.session.member.domain.constant.LoginStaticField.MEMBER_SESSION;
+import static com.example.login.global.member.domain.MemberSession.MEMBER_SESSION;
 
 @Slf4j
 @RequiredArgsConstructor


### PR DESCRIPTION
* token에서도 member 도메인을 일부 사용하기 때문에 공통으로 사용하는 것들을 global/member로 옮겨주었다.

* LoginStaticField의 static field는 MemberSession객체로 옮김