### PR TITLE
Feature/#7 jwt argument resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
-src/main/resources/application.yml
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/login/global/error/ErrorStaticField.java
+++ b/src/main/java/com/example/login/global/error/ErrorStaticField.java
@@ -17,5 +17,11 @@ public class ErrorStaticField {
     public static final String INVALID_PASSWORD = "비밀번호가 올바르지 않습니다.";
     public static final String BINDING_ERROR = "잘못된 Form 형식입니다.";
     public static final String REQUEST_BODY_NOT_FOUND = "ReqeustBody에 입력된 내용이 없습니다.";
+    public static final String INVALID_REFRESH_TOKEN = "Refresh 토큰 인증에 실패하였습니다.";
+    public static final String INVALID_ACCESS_TOKEN = "Access 토큰 인증에 실패하였습니다.";
+    public static final String EXPIRED_REFRESH_TOKEN = "Refresh 토큰만료! 재로그인 하세요.";
+    public static final String EXPIRED_ACCESS_TOKEN = "Access 토큰만료! 재시도 하세요.";
+
+
 
 }

--- a/src/main/java/com/example/login/token/jwt/argumentresolver/JwtArgumentResolverWebConfig.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/JwtArgumentResolverWebConfig.java
@@ -1,0 +1,23 @@
+package com.example.login.token.jwt.argumentresolver;
+
+import com.example.login.global.member.repository.MemberRepository;
+import com.example.login.token.jwt.member.service.JwtValidateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class JwtArgumentResolverWebConfig implements WebMvcConfigurer {
+
+    private final MemberRepository memberRepository;
+    private final JwtValidateService jwtValidateService;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new JwtLoginArgumentResolver(memberRepository, jwtValidateService));
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLogin.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLogin.java
@@ -1,0 +1,11 @@
+package com.example.login.token.jwt.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JwtLogin {
+}

--- a/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLoginArgumentResolver.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLoginArgumentResolver.java
@@ -1,0 +1,43 @@
+package com.example.login.token.jwt.argumentresolver;
+
+import com.example.login.global.member.domain.Member;
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.exception.MemberNotFoundException;
+import com.example.login.global.member.repository.MemberRepository;
+import com.example.login.token.jwt.member.service.JwtValidateService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtLoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
+    private final JwtValidateService jwtValidateService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        log.info("JwtLoginArgumentResolver supportsParameter 실행");
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(JwtLogin.class);
+        boolean hasMemberSessionType = MemberSession.class.isAssignableFrom(parameter.getParameterType());
+        return hasLoginAnnotation && hasMemberSessionType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        log.info("JwtLoginArgumentResolver resolveArgument 실행");
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        Claims claims = jwtValidateService.validateToken(request);
+        String userId = claims.getSubject();
+        Member member = memberRepository.findByUserId(userId).orElseThrow(MemberNotFoundException::new);
+        return MemberSession.from(member);
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/argumentresolver/controller/JwtArgumentResolverLoginController.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/controller/JwtArgumentResolverLoginController.java
@@ -1,0 +1,49 @@
+package com.example.login.token.jwt.argumentresolver.controller;
+
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.dto.LoginForm;
+import com.example.login.global.member.dto.SignUpForm;
+import com.example.login.token.jwt.argumentresolver.JwtLogin;
+import com.example.login.token.jwt.member.dto.MemberWithTokenResponse;
+import com.example.login.token.jwt.member.service.JwtLoginService;
+import com.example.login.token.jwt.member.service.JwtMemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/jwt/argument-resolver")
+@RestController
+public class JwtArgumentResolverLoginController {
+
+    private final JwtLoginService jwtLoginService;
+    private final JwtMemberService memberService;
+
+    @GetMapping("/get")
+    public MemberWithTokenResponse get(@JwtLogin MemberSession memberSession) {
+        return MemberWithTokenResponse.from(memberService.getBySession(memberSession));
+    }
+
+    @PostMapping("/sign-up")
+    public MemberWithTokenResponse signUp(@RequestBody @Valid SignUpForm signUpForm) {
+        return MemberWithTokenResponse.withoutToken(jwtLoginService.signUp(signUpForm));
+    }
+
+    @PostMapping("/login")
+    public MemberWithTokenResponse login(
+            @RequestBody @Valid LoginForm loginForm,
+            HttpServletRequest request,
+            HttpServletResponse response
+            ) {
+        MemberWithTokenResponse memberWithTokenResponse = MemberWithTokenResponse.from(jwtLoginService.login(loginForm, request, response));
+        return memberWithTokenResponse;
+    }
+
+    @GetMapping("/logout")
+    public String logout(@JwtLogin MemberSession memberSession, HttpServletRequest request) {
+        jwtLoginService.logout(memberSession);
+        return "success";
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/domain/RefreshToken.java
+++ b/src/main/java/com/example/login/token/jwt/member/domain/RefreshToken.java
@@ -1,0 +1,9 @@
+package com.example.login.token.jwt.member.domain;
+
+import lombok.Getter;
+
+public record RefreshToken(String refreshToken) {
+    public static RefreshToken of(String refreshToken){
+        return new RefreshToken(refreshToken);
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/dto/MemberWithTokenDto.java
+++ b/src/main/java/com/example/login/token/jwt/member/dto/MemberWithTokenDto.java
@@ -1,0 +1,31 @@
+package com.example.login.token.jwt.member.dto;
+
+import com.example.login.global.member.domain.Member;
+import lombok.Builder;
+
+public record MemberWithTokenDto(
+        Long id,
+        String username,
+        String userId,
+        String accessToken
+){
+
+    @Builder
+    public MemberWithTokenDto {
+    }
+
+    public static MemberWithTokenDto from(Member entity, String accessToken) {
+        return MemberWithTokenDto.builder()
+                .id(entity.getId())
+                .username(entity.getUsername())
+                .userId(entity.getUserId())
+                .accessToken(accessToken).build();
+    }
+
+    public static MemberWithTokenDto withoutToken(Member entity) {
+        return MemberWithTokenDto.builder()
+                .id(entity.getId())
+                .username(entity.getUsername())
+                .userId(entity.getUserId()).build();
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/dto/MemberWithTokenResponse.java
+++ b/src/main/java/com/example/login/token/jwt/member/dto/MemberWithTokenResponse.java
@@ -1,0 +1,29 @@
+package com.example.login.token.jwt.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MemberWithTokenResponse(
+        String username,
+        String userId,
+        String accessToken
+) {
+
+    @Builder
+    public MemberWithTokenResponse {
+    }
+
+    public static MemberWithTokenResponse from(MemberWithTokenDto dto) {
+        return MemberWithTokenResponse.builder()
+                .username(dto.username())
+                .userId(dto.userId())
+                .accessToken(dto.accessToken()).build();
+    }
+
+    public static MemberWithTokenResponse withoutToken(MemberWithTokenDto dto) {
+        return MemberWithTokenResponse.builder()
+                .username(dto.username())
+                .userId(dto.userId()).build();
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/dto/SecretKey.java
+++ b/src/main/java/com/example/login/token/jwt/member/dto/SecretKey.java
@@ -1,0 +1,13 @@
+package com.example.login.token.jwt.member.dto;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+
+@Component
+public record SecretKey(@Value("${jwt.secretKey}") String value) {
+    public byte[] getDecoded() {
+        return Base64.getDecoder().decode(value);
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/exception/ExpiredAccessTokenException.java
+++ b/src/main/java/com/example/login/token/jwt/member/exception/ExpiredAccessTokenException.java
@@ -1,0 +1,9 @@
+package com.example.login.token.jwt.member.exception;
+
+import com.example.login.global.exception.UnauthorizedException;
+
+public class ExpiredAccessTokenException extends UnauthorizedException {
+    public ExpiredAccessTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/exception/ExpiredRefreshTokenException.java
+++ b/src/main/java/com/example/login/token/jwt/member/exception/ExpiredRefreshTokenException.java
@@ -1,0 +1,12 @@
+package com.example.login.token.jwt.member.exception;
+
+import com.example.login.global.exception.UnauthorizedException;
+
+import static com.example.login.global.error.ErrorStaticField.EXPIRED_REFRESH_TOKEN;
+
+public class ExpiredRefreshTokenException extends UnauthorizedException {
+    private static final String MESSAGE = EXPIRED_REFRESH_TOKEN;
+    public ExpiredRefreshTokenException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/exception/InvalidAccessTokenException.java
+++ b/src/main/java/com/example/login/token/jwt/member/exception/InvalidAccessTokenException.java
@@ -1,0 +1,12 @@
+package com.example.login.token.jwt.member.exception;
+
+import com.example.login.global.exception.UnauthorizedException;
+
+import static com.example.login.global.error.ErrorStaticField.INVALID_ACCESS_TOKEN;
+
+public class InvalidAccessTokenException extends UnauthorizedException {
+    private static final String MESSAGE = INVALID_ACCESS_TOKEN;
+    public InvalidAccessTokenException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/example/login/token/jwt/member/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,12 @@
+package com.example.login.token.jwt.member.exception;
+
+import com.example.login.global.exception.UnauthorizedException;
+
+import static com.example.login.global.error.ErrorStaticField.INVALID_REFRESH_TOKEN;
+
+public class InvalidRefreshTokenException extends UnauthorizedException {
+    private static final String MESSAGE = INVALID_REFRESH_TOKEN;
+    public InvalidRefreshTokenException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/login/token/jwt/member/repository/RefreshTokenRepository.java
@@ -1,0 +1,32 @@
+package com.example.login.token.jwt.member.repository;
+
+import com.example.login.token.jwt.member.domain.RefreshToken;
+import lombok.Getter;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Getter
+@Repository
+public class RefreshTokenRepository {
+
+    Map<String, Set<RefreshToken>> validRefreshTokens = new HashMap<>();
+
+    public String save(String userId, String refreshToken) {
+        Set<RefreshToken> refreshTokens = validRefreshTokens.getOrDefault(userId, new HashSet<>());
+        refreshTokens.add(RefreshToken.of(refreshToken));
+        validRefreshTokens.put(userId, refreshTokens);
+        return refreshToken;
+    }
+
+    public void invalidate(String userId) {
+        validRefreshTokens.remove(userId);
+    }
+
+    public void clear() {
+        validRefreshTokens.clear();
+    }
+
+
+
+}

--- a/src/main/java/com/example/login/token/jwt/member/service/JwtLoginService.java
+++ b/src/main/java/com/example/login/token/jwt/member/service/JwtLoginService.java
@@ -1,0 +1,47 @@
+package com.example.login.token.jwt.member.service;
+
+
+import com.example.login.global.member.domain.Member;
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.dto.LoginForm;
+import com.example.login.global.member.dto.SignUpForm;
+import com.example.login.global.member.exception.MemberNotFoundException;
+import com.example.login.global.member.exception.MemberPasswordNotMatchException;
+import com.example.login.global.member.repository.MemberRepository;
+import com.example.login.token.jwt.member.dto.MemberWithTokenDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class JwtLoginService {
+    private final JwtMemberService jwtMemberService;
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public MemberWithTokenDto signUp(SignUpForm signUpForm) {
+        return jwtMemberService.save(signUpForm);
+    }
+
+    public MemberWithTokenDto login(LoginForm loginForm, HttpServletRequest request, HttpServletResponse response) {
+        Member member = memberRepository.findByUserId(loginForm.userId()).orElseThrow(MemberNotFoundException::new);
+        if (passwordEncoder.matches(loginForm.password(), member.getPassword())) {
+            String accessToken = jwtProvider.createAccessToken(loginForm.userId());
+            String refreshToken = jwtProvider.createRefreshToken(loginForm.userId());
+            jwtProvider.setCookie(response, refreshToken);
+            return MemberWithTokenDto.from(member, accessToken);
+        }
+        throw new MemberPasswordNotMatchException();
+    }
+
+    public void logout(MemberSession memberSession) {
+        jwtProvider.expiredRefreshToken(memberSession.userId());
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/service/JwtMemberService.java
+++ b/src/main/java/com/example/login/token/jwt/member/service/JwtMemberService.java
@@ -1,0 +1,50 @@
+package com.example.login.token.jwt.member.service;
+
+import com.example.login.global.member.domain.Member;
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.dto.SignUpForm;
+import com.example.login.global.member.exception.MemberDuplicationException;
+import com.example.login.global.member.exception.MemberNotFoundException;
+import com.example.login.global.member.repository.MemberRepository;
+import com.example.login.token.jwt.member.dto.MemberWithTokenDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class JwtMemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public MemberWithTokenDto save(SignUpForm signUpForm) {
+        validDupUserId(signUpForm.userId());
+        return MemberWithTokenDto.withoutToken(memberRepository.save(signUpForm.toEntity(passwordEncoder)));
+    }
+
+    private void validDupUserId(String userId) {
+        Optional<Member> optionalUser = memberRepository.findByUserId(userId);
+        if (optionalUser.isPresent()) {
+            throw new MemberDuplicationException();
+        }
+    }
+
+    public MemberWithTokenDto getBySession(MemberSession session) {
+        return memberRepository.findByUserId(session.userId())
+                .map(MemberWithTokenDto::withoutToken)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
+    @Transactional
+    public void delete(MemberSession memberSession) {
+        memberRepository.deleteById(memberSession.id());
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/service/JwtProvider.java
+++ b/src/main/java/com/example/login/token/jwt/member/service/JwtProvider.java
@@ -1,0 +1,62 @@
+package com.example.login.token.jwt.member.service;
+
+import com.example.login.token.jwt.member.dto.SecretKey;
+import com.example.login.token.jwt.member.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final long accessTokenExpiration = 1000L * 60 * 15; // Access token is 15 minutes.
+    private final long refreshTokenExpiration = 1000L * 60 * 60 * 24; // Refresh token is one day.
+
+    public String createAccessToken(String userId) {
+        byte[] decodedSecretKey = secretKey.getDecoded();
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .signWith(Keys.hmacShaKeyFor(decodedSecretKey))
+                .compact();
+    }
+
+    public String createRefreshToken(String userId) {
+        byte[] decodedSecretKey = secretKey.getDecoded();
+        String refreshToken = Jwts.builder()
+                .setSubject(userId)
+                .setId(UUID.randomUUID().toString()) // Unique ID for refresh token
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .signWith(Keys.hmacShaKeyFor(decodedSecretKey))
+                .compact();
+
+        return refreshTokenRepository.save(userId, refreshToken);
+    }
+
+    public void setCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from(HttpHeaders.SET_COOKIE, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(Duration.ofDays(30))
+                .build();
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    public void expiredRefreshToken(String userId) {
+        refreshTokenRepository.invalidate(userId);
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/service/JwtValidateService.java
+++ b/src/main/java/com/example/login/token/jwt/member/service/JwtValidateService.java
@@ -1,0 +1,83 @@
+package com.example.login.token.jwt.member.service;
+
+import com.example.login.token.jwt.member.domain.RefreshToken;
+import com.example.login.token.jwt.member.dto.SecretKey;
+import com.example.login.token.jwt.member.exception.ExpiredAccessTokenException;
+import com.example.login.token.jwt.member.exception.ExpiredRefreshTokenException;
+import com.example.login.token.jwt.member.exception.InvalidAccessTokenException;
+import com.example.login.token.jwt.member.exception.InvalidRefreshTokenException;
+import com.example.login.token.jwt.member.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Service
+public class JwtValidateService {
+
+    private final SecretKey secretKey;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+
+    public Claims validateToken(HttpServletRequest request) {
+        String accessToken = request.getHeader("AccessToken");
+        byte[] decodedSecretKey = secretKey.getDecoded();
+
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(decodedSecretKey)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            Claims claims = validateRefreshToken(request);
+            throw new ExpiredAccessTokenException("Acess토큰 만료! 새로 발급된 AccessToken: " +
+                    jwtProvider.createAccessToken(claims.getSubject()));
+        } catch (Exception e) {
+            throw new InvalidAccessTokenException();
+        }
+    }
+
+    private Claims validateRefreshToken(HttpServletRequest request) {
+        String refreshToken = getRefreshTokenFromRequest(request);
+        verifyValidRefreshToken(refreshToken);
+        byte[] decodedSecretKey = secretKey.getDecoded();
+
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(decodedSecretKey)
+                    .build()
+                    .parseClaimsJws(refreshToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredRefreshTokenException();
+        } catch (Exception e) {
+            throw new InvalidRefreshTokenException();
+        }
+    }
+
+    private String getRefreshTokenFromRequest(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(HttpHeaders.SET_COOKIE))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow(InvalidRefreshTokenException::new);
+    }
+
+    private void verifyValidRefreshToken(String refreshToken) {
+        Map<String, Set<RefreshToken>> validRefreshTokens = refreshTokenRepository.getValidRefreshTokens();
+        if (validRefreshTokens.values().stream().noneMatch(set -> set.contains(RefreshToken.of(refreshToken)))) {
+            throw new InvalidRefreshTokenException();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+
+jwt.secretKey: ${JWT_SECRET_KEY}


### PR DESCRIPTION
* `JwtProvider`는 토큰 생성, 쿠키에 저장, 토큰 만료 등을 하며, `JwtLoginService`에서 주로 사용

* `JwtValidateService`는 토큰이 유효한지 판단하며 `RefreshToken`이 유효하다면 `AccessToken`을 재발급해주는 기능을함. `ArgumentResolver`에서 토큰의 유효성을 판단하기 위해 사용.