### PR TITLE
#8 - jwt 인증에서 인증방식 변경

### DIFF
--- a/src/main/java/com/example/login/global/error/ErrorStaticField.java
+++ b/src/main/java/com/example/login/global/error/ErrorStaticField.java
@@ -9,10 +9,10 @@ public class ErrorStaticField {
     public static final int OK = 200;
     public static final int CREATED = 201;
 
-    public static final String CONVERSION_ERROR = "Long으로 변환 불가능한 타입이 URL에 입력되었습니다";
+    public static final String CONVERSION_ERROR = "변환 불가능한 타입이 URL에 입력되었습니다";
     public static final String USER_NOT_FOUND = "존재하지 않는 회원입니다.";
     public static final String DUP_LOGIN_ID = "이미 사용중인 아이디 입니다.";
-    public static final String USER_UNAUTHORIZED = "Member 로그인이 필요한 서비스 입니다.";
+    public static final String USER_UNAUTHORIZED = "로그인이 필요한 서비스 입니다.";
     public static final String INVALID_ID = "존재하지 않는 아이디 입니다.";
     public static final String INVALID_PASSWORD = "비밀번호가 올바르지 않습니다.";
     public static final String BINDING_ERROR = "잘못된 Form 형식입니다.";
@@ -20,7 +20,7 @@ public class ErrorStaticField {
     public static final String INVALID_REFRESH_TOKEN = "Refresh 토큰 인증에 실패하였습니다.";
     public static final String INVALID_ACCESS_TOKEN = "Access 토큰 인증에 실패하였습니다.";
     public static final String EXPIRED_REFRESH_TOKEN = "Refresh 토큰만료! 재로그인 하세요.";
-    public static final String EXPIRED_ACCESS_TOKEN = "Access 토큰만료! 재시도 하세요.";
+    public static final String EXPIRED_ACCESS_TOKEN = "Access 토큰만료! 재발급 받아주세요.";
 
 
 

--- a/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLoginArgumentResolver.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLoginArgumentResolver.java
@@ -15,6 +15,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import static com.example.login.token.jwt.member.basic.JwtStaticField.REFRESH_URL;
+
 @RequiredArgsConstructor
 @Slf4j
 public class JwtLoginArgumentResolver implements HandlerMethodArgumentResolver {
@@ -35,9 +37,16 @@ public class JwtLoginArgumentResolver implements HandlerMethodArgumentResolver {
         log.info("JwtLoginArgumentResolver resolveArgument 실행");
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
-        Claims claims = jwtValidateService.validateToken(request);
+        Claims claims = this.getClaims(request);
         String userId = claims.getSubject();
         Member member = memberRepository.findByUserId(userId).orElseThrow(MemberNotFoundException::new);
         return MemberSession.from(member);
+    }
+
+    private Claims getClaims(HttpServletRequest request) {
+        if (!REFRESH_URL.equals(request.getRequestURI())) {
+            return jwtValidateService.validateAccessToken(request);
+        }
+        return jwtValidateService.validateRefreshToken(request);
     }
 }

--- a/src/main/java/com/example/login/token/jwt/argumentresolver/controller/JwtArgumentResolverLoginController.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/controller/JwtArgumentResolverLoginController.java
@@ -7,6 +7,7 @@ import com.example.login.token.jwt.argumentresolver.JwtLogin;
 import com.example.login.token.jwt.member.dto.MemberWithTokenResponse;
 import com.example.login.token.jwt.member.service.JwtLoginService;
 import com.example.login.token.jwt.member.service.JwtMemberService;
+import com.example.login.token.jwt.member.service.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -20,6 +21,14 @@ public class JwtArgumentResolverLoginController {
 
     private final JwtLoginService jwtLoginService;
     private final JwtMemberService memberService;
+
+    @PostMapping("/token")
+    public String refresh(
+            @JwtLogin MemberSession memberSession,
+            HttpServletResponse response) {
+        jwtLoginService.refresh(memberSession, response);
+        return "Successful";
+    }
 
     @GetMapping("/get")
     public MemberWithTokenResponse get(@JwtLogin MemberSession memberSession) {

--- a/src/main/java/com/example/login/token/jwt/member/basic/JwtStaticField.java
+++ b/src/main/java/com/example/login/token/jwt/member/basic/JwtStaticField.java
@@ -1,0 +1,6 @@
+package com.example.login.token.jwt.member.basic;
+
+public class JwtStaticField {
+    public static final String BEARER = "Bearer ";
+    public static final String REFRESH_URL = "/jwt/argument-resolver/token";
+}

--- a/src/main/java/com/example/login/token/jwt/member/dto/MemberWithTokenDto.java
+++ b/src/main/java/com/example/login/token/jwt/member/dto/MemberWithTokenDto.java
@@ -3,23 +3,25 @@ package com.example.login.token.jwt.member.dto;
 import com.example.login.global.member.domain.Member;
 import lombok.Builder;
 
+import static com.example.login.token.jwt.member.basic.JwtStaticField.BEARER;
+
 public record MemberWithTokenDto(
         Long id,
         String username,
         String userId,
-        String accessToken
+        String refreshToken
 ){
 
     @Builder
     public MemberWithTokenDto {
     }
 
-    public static MemberWithTokenDto from(Member entity, String accessToken) {
+    public static MemberWithTokenDto from(Member entity, String refreshToken) {
         return MemberWithTokenDto.builder()
                 .id(entity.getId())
                 .username(entity.getUsername())
                 .userId(entity.getUserId())
-                .accessToken(accessToken).build();
+                .refreshToken(BEARER + refreshToken).build();
     }
 
     public static MemberWithTokenDto withoutToken(Member entity) {

--- a/src/main/java/com/example/login/token/jwt/member/dto/MemberWithTokenResponse.java
+++ b/src/main/java/com/example/login/token/jwt/member/dto/MemberWithTokenResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 public record MemberWithTokenResponse(
         String username,
         String userId,
-        String accessToken
+        String refreshToken
 ) {
 
     @Builder
@@ -18,7 +18,7 @@ public record MemberWithTokenResponse(
         return MemberWithTokenResponse.builder()
                 .username(dto.username())
                 .userId(dto.userId())
-                .accessToken(dto.accessToken()).build();
+                .refreshToken(dto.refreshToken()).build();
     }
 
     public static MemberWithTokenResponse withoutToken(MemberWithTokenDto dto) {

--- a/src/main/java/com/example/login/token/jwt/member/exception/ExpiredAccessTokenException.java
+++ b/src/main/java/com/example/login/token/jwt/member/exception/ExpiredAccessTokenException.java
@@ -2,8 +2,12 @@ package com.example.login.token.jwt.member.exception;
 
 import com.example.login.global.exception.UnauthorizedException;
 
+import static com.example.login.global.error.ErrorStaticField.EXPIRED_ACCESS_TOKEN;
+
 public class ExpiredAccessTokenException extends UnauthorizedException {
-    public ExpiredAccessTokenException(String message) {
-        super(message);
+    public static final String MESSAGE = EXPIRED_ACCESS_TOKEN;
+
+    public ExpiredAccessTokenException() {
+        super(MESSAGE);
     }
 }

--- a/src/main/java/com/example/login/token/jwt/member/service/JwtLoginService.java
+++ b/src/main/java/com/example/login/token/jwt/member/service/JwtLoginService.java
@@ -35,10 +35,15 @@ public class JwtLoginService {
         if (passwordEncoder.matches(loginForm.password(), member.getPassword())) {
             String accessToken = jwtProvider.createAccessToken(loginForm.userId());
             String refreshToken = jwtProvider.createRefreshToken(loginForm.userId());
-            jwtProvider.setCookie(response, refreshToken);
-            return MemberWithTokenDto.from(member, accessToken);
+            jwtProvider.setAuthorizationHeader(response, accessToken);
+            return MemberWithTokenDto.from(member, refreshToken);
         }
         throw new MemberPasswordNotMatchException();
+    }
+
+    public void refresh(MemberSession memberSession, HttpServletResponse response) {
+        String accessToken = jwtProvider.createAccessToken(memberSession.userId());
+        jwtProvider.setAuthorizationHeader(response, accessToken);
     }
 
     public void logout(MemberSession memberSession) {

--- a/src/main/java/com/example/login/token/jwt/member/service/JwtProvider.java
+++ b/src/main/java/com/example/login/token/jwt/member/service/JwtProvider.java
@@ -2,6 +2,7 @@ package com.example.login.token.jwt.member.service;
 
 import com.example.login.token.jwt.member.dto.SecretKey;
 import com.example.login.token.jwt.member.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
+
+import static com.example.login.token.jwt.member.basic.JwtStaticField.BEARER;
 
 @RequiredArgsConstructor
 @Service
@@ -47,13 +50,8 @@ public class JwtProvider {
         return refreshTokenRepository.save(userId, refreshToken);
     }
 
-    public void setCookie(HttpServletResponse response, String refreshToken) {
-        ResponseCookie cookie = ResponseCookie.from(HttpHeaders.SET_COOKIE, refreshToken)
-                .httpOnly(true)
-                .secure(true)
-                .maxAge(Duration.ofDays(30))
-                .build();
-        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    public void setAuthorizationHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(HttpHeaders.AUTHORIZATION, BEARER + accessToken);
     }
 
     public void expiredRefreshToken(String userId) {


### PR DESCRIPTION
## 기존
* 토큰 유효성 검사시 AccessToekn이 만료되면 자동으로 RefreshToken의 유효성을 검사하고, 예외를 발생시며 AccessToken을 재발급 해줌.
* 기존에는 AccessToken을 AccessToken헤더에, RefreshToken을 쿠키에 담아 전달.

## 변경
* AccessToken은 Autorization헤더에, RefreshToken은 body에 담아 전달.
* AccessToken이 만료되었을 경우, 401에러를 발생시킴.
* 클라이언트는 해당 에러를 보고, Local Storage에 저장해둔 RefreshToken을 Authrization헤더에 담아 `/token` URL에 `Post`방식으로 전달. 
* 서버는 RefreshToken의 유효성을 검사하고 유효하다면, 새로 발급한 AccessToken을 Authroization에 담아 전달.