### PR TITLE
#9 - jwt를 이용한 ArgumentResolver + Interceptor 로그인 인증 구현

### DIFF
--- a/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLoginArgumentResolverV1.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLoginArgumentResolverV1.java
@@ -19,7 +19,7 @@ import static com.example.login.token.jwt.member.basic.JwtStaticField.REFRESH_UR
 
 @RequiredArgsConstructor
 @Slf4j
-public class JwtLoginArgumentResolver implements HandlerMethodArgumentResolver {
+public class JwtLoginArgumentResolverV1 implements HandlerMethodArgumentResolver {
 
     private final MemberRepository memberRepository;
     private final JwtValidateService jwtValidateService;
@@ -27,7 +27,7 @@ public class JwtLoginArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         log.info("JwtLoginArgumentResolver supportsParameter 실행");
-        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(JwtLogin.class);
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(JwtLoginV1.class);
         boolean hasMemberSessionType = MemberSession.class.isAssignableFrom(parameter.getParameterType());
         return hasLoginAnnotation && hasMemberSessionType;
     }
@@ -44,7 +44,7 @@ public class JwtLoginArgumentResolver implements HandlerMethodArgumentResolver {
     }
 
     private Claims getClaims(HttpServletRequest request) {
-        if (!REFRESH_URL.equals(request.getRequestURI())) {
+        if (!request.getRequestURI().contains(REFRESH_URL)) {
             return jwtValidateService.validateAccessToken(request);
         }
         return jwtValidateService.validateRefreshToken(request);

--- a/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLoginV1.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/JwtLoginV1.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface JwtLogin {
+public @interface JwtLoginV1 {
 }

--- a/src/main/java/com/example/login/token/jwt/argumentresolver/JwtWebConfigV1.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/JwtWebConfigV1.java
@@ -1,0 +1,23 @@
+package com.example.login.token.jwt.argumentresolver;
+
+import com.example.login.global.member.repository.MemberRepository;
+import com.example.login.token.jwt.member.service.JwtValidateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class JwtWebConfigV1 implements WebMvcConfigurer {
+
+    private final MemberRepository memberRepository;
+    private final JwtValidateService jwtValidateService;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new JwtLoginArgumentResolverV1(memberRepository, jwtValidateService));
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/argumentresolver/controller/JwtLoginControllerV1.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver/controller/JwtLoginControllerV1.java
@@ -3,11 +3,10 @@ package com.example.login.token.jwt.argumentresolver.controller;
 import com.example.login.global.member.domain.MemberSession;
 import com.example.login.global.member.dto.LoginForm;
 import com.example.login.global.member.dto.SignUpForm;
-import com.example.login.token.jwt.argumentresolver.JwtLogin;
+import com.example.login.token.jwt.argumentresolver.JwtLoginV1;
 import com.example.login.token.jwt.member.dto.MemberWithTokenResponse;
 import com.example.login.token.jwt.member.service.JwtLoginService;
 import com.example.login.token.jwt.member.service.JwtMemberService;
-import com.example.login.token.jwt.member.service.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -15,23 +14,23 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/jwt/argument-resolver")
+@RequestMapping("/jwt/v1")
 @RestController
-public class JwtArgumentResolverLoginController {
+public class JwtLoginControllerV1 {
 
     private final JwtLoginService jwtLoginService;
     private final JwtMemberService memberService;
 
     @PostMapping("/token")
     public String refresh(
-            @JwtLogin MemberSession memberSession,
+            @JwtLoginV1 MemberSession memberSession,
             HttpServletResponse response) {
         jwtLoginService.refresh(memberSession, response);
-        return "Successful";
+        return "success";
     }
 
     @GetMapping("/get")
-    public MemberWithTokenResponse get(@JwtLogin MemberSession memberSession) {
+    public MemberWithTokenResponse get(@JwtLoginV1 MemberSession memberSession) {
         return MemberWithTokenResponse.from(memberService.getBySession(memberSession));
     }
 
@@ -51,7 +50,7 @@ public class JwtArgumentResolverLoginController {
     }
 
     @GetMapping("/logout")
-    public String logout(@JwtLogin MemberSession memberSession, HttpServletRequest request) {
+    public String logout(@JwtLoginV1 MemberSession memberSession, HttpServletRequest request) {
         jwtLoginService.logout(memberSession);
         return "success";
     }

--- a/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/JwtLoginArgumentResolverV2.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/JwtLoginArgumentResolverV2.java
@@ -1,0 +1,30 @@
+package com.example.login.token.jwt.argumentresolver_interceptor;
+
+import com.example.login.global.member.domain.MemberSession;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+public class JwtLoginArgumentResolverV2 implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        log.info("JwtLoginArgumentResolverV2 supportsParameter 실행");
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(JwtLoginV2.class);
+        boolean hasMemberSessionType = MemberSession.class.isAssignableFrom(parameter.getParameterType());
+        return hasLoginAnnotation && hasMemberSessionType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        log.info("JwtLoginArgumentResolverV2 resolveArgument 실행");
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        return request.getAttribute("MemberSession");
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/JwtLoginCheckInterceptor.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/JwtLoginCheckInterceptor.java
@@ -1,0 +1,43 @@
+package com.example.login.token.jwt.argumentresolver_interceptor;
+
+import com.example.login.global.member.domain.Member;
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.exception.MemberNotFoundException;
+import com.example.login.global.member.repository.MemberRepository;
+import com.example.login.token.jwt.member.service.JwtValidateService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import static com.example.login.token.jwt.member.basic.JwtStaticField.REFRESH_URL;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtLoginCheckInterceptor implements HandlerInterceptor {
+
+    private final MemberRepository memberRepository;
+    private final JwtValidateService jwtValidateService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception{
+        String requestURI = request.getRequestURI();
+
+        log.info("MEMBER 로그인 인증 인터 셉터 실행 [{}]", requestURI);
+        Claims claims = this.getClaims(request);
+        String userId = claims.getSubject();
+        Member member = memberRepository.findByUserId(userId).orElseThrow(MemberNotFoundException::new);
+        request.setAttribute("MemberSession", MemberSession.from(member));
+        log.info("MEMBER 로그인 확인 성공");
+        return true;
+    }
+
+    private Claims getClaims(HttpServletRequest request) {
+        if (!request.getRequestURI().contains(REFRESH_URL)) {
+            return jwtValidateService.validateAccessToken(request);
+        }
+        return jwtValidateService.validateRefreshToken(request);
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/JwtLoginV2.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/JwtLoginV2.java
@@ -1,0 +1,11 @@
+package com.example.login.token.jwt.argumentresolver_interceptor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JwtLoginV2 {
+}

--- a/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/JwtWebConfigV2.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/JwtWebConfigV2.java
@@ -1,23 +1,32 @@
-package com.example.login.token.jwt.argumentresolver;
+package com.example.login.token.jwt.argumentresolver_interceptor;
 
 import com.example.login.global.member.repository.MemberRepository;
 import com.example.login.token.jwt.member.service.JwtValidateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
 @RequiredArgsConstructor
 @Configuration
-public class JwtArgumentResolverWebConfig implements WebMvcConfigurer {
+public class JwtWebConfigV2 implements WebMvcConfigurer {
 
     private final MemberRepository memberRepository;
     private final JwtValidateService jwtValidateService;
 
     @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new JwtLoginCheckInterceptor(memberRepository, jwtValidateService))
+                .order(1)
+                .addPathPatterns("/jwt/v2/**")
+                .excludePathPatterns("/jwt/v2/sign-up", "/jwt/v2/login");
+    }
+
+    @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new JwtLoginArgumentResolver(memberRepository, jwtValidateService));
+        resolvers.add(new JwtLoginArgumentResolverV2());
     }
 }

--- a/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/controller/JwtLoginControllerV2.java
+++ b/src/main/java/com/example/login/token/jwt/argumentresolver_interceptor/controller/JwtLoginControllerV2.java
@@ -1,0 +1,57 @@
+package com.example.login.token.jwt.argumentresolver_interceptor.controller;
+
+import com.example.login.global.member.domain.MemberSession;
+import com.example.login.global.member.dto.LoginForm;
+import com.example.login.global.member.dto.SignUpForm;
+import com.example.login.token.jwt.argumentresolver.JwtLoginV1;
+import com.example.login.token.jwt.member.dto.MemberWithTokenResponse;
+import com.example.login.token.jwt.member.service.JwtLoginService;
+import com.example.login.token.jwt.member.service.JwtMemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/jwt/v2")
+@RestController
+public class JwtLoginControllerV2 {
+
+    private final JwtLoginService jwtLoginService;
+    private final JwtMemberService memberService;
+
+    @PostMapping("/token")
+    public String refresh(
+            @JwtLoginV1 MemberSession memberSession,
+            HttpServletResponse response) {
+        jwtLoginService.refresh(memberSession, response);
+        return "success";
+    }
+
+    @GetMapping("/get")
+    public MemberWithTokenResponse get(@JwtLoginV1 MemberSession memberSession) {
+        return MemberWithTokenResponse.from(memberService.getBySession(memberSession));
+    }
+
+    @PostMapping("/sign-up")
+    public MemberWithTokenResponse signUp(@RequestBody @Valid SignUpForm signUpForm) {
+        return MemberWithTokenResponse.withoutToken(jwtLoginService.signUp(signUpForm));
+    }
+
+    @PostMapping("/login")
+    public MemberWithTokenResponse login(
+            @RequestBody @Valid LoginForm loginForm,
+            HttpServletRequest request,
+            HttpServletResponse response
+            ) {
+        MemberWithTokenResponse memberWithTokenResponse = MemberWithTokenResponse.from(jwtLoginService.login(loginForm, request, response));
+        return memberWithTokenResponse;
+    }
+
+    @GetMapping("/logout")
+    public String logout(@JwtLoginV1 MemberSession memberSession, HttpServletRequest request) {
+        jwtLoginService.logout(memberSession);
+        return "success";
+    }
+}

--- a/src/main/java/com/example/login/token/jwt/member/basic/JwtStaticField.java
+++ b/src/main/java/com/example/login/token/jwt/member/basic/JwtStaticField.java
@@ -2,5 +2,5 @@ package com.example.login.token.jwt.member.basic;
 
 public class JwtStaticField {
     public static final String BEARER = "Bearer ";
-    public static final String REFRESH_URL = "/jwt/argument-resolver/token";
+    public static final String REFRESH_URL = "/token";
 }

--- a/src/main/java/com/example/login/token/jwt/member/provider/JwtProvider.java
+++ b/src/main/java/com/example/login/token/jwt/member/provider/JwtProvider.java
@@ -1,4 +1,4 @@
-package com.example.login.token.jwt.member.service;
+package com.example.login.token.jwt.member.provider;
 
 import com.example.login.token.jwt.member.dto.SecretKey;
 import com.example.login.token.jwt.member.repository.RefreshTokenRepository;

--- a/src/main/java/com/example/login/token/jwt/member/service/JwtLoginService.java
+++ b/src/main/java/com/example/login/token/jwt/member/service/JwtLoginService.java
@@ -9,6 +9,7 @@ import com.example.login.global.member.exception.MemberNotFoundException;
 import com.example.login.global.member.exception.MemberPasswordNotMatchException;
 import com.example.login.global.member.repository.MemberRepository;
 import com.example.login.token.jwt.member.dto.MemberWithTokenDto;
+import com.example.login.token.jwt.member.provider.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/login/token/jwt/member/service/JwtValidateService.java
+++ b/src/main/java/com/example/login/token/jwt/member/service/JwtValidateService.java
@@ -6,17 +6,16 @@ import com.example.login.token.jwt.member.exception.ExpiredAccessTokenException;
 import com.example.login.token.jwt.member.exception.ExpiredRefreshTokenException;
 import com.example.login.token.jwt.member.exception.InvalidAccessTokenException;
 import com.example.login.token.jwt.member.exception.InvalidRefreshTokenException;
+import com.example.login.token.jwt.member.provider.JwtProvider;
 import com.example.login.token.jwt.member.repository.RefreshTokenRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 


### PR DESCRIPTION
* interceptor에서는 토큰이 유효한지에 대한 기능에 집중.
* argumentresolver에서는 어노테이션 확인 및 MemberSession으로의 변환 기능에 집중함.

* `!REFRESH_URL.equals(request.getRequestURI())` 이 동작하지 않아서  `!request.getRequestURI().contains(REFRESH_URL)`로 변경